### PR TITLE
Added a link to notes on the TC Camp session

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ Please remember to fill out the TC Camp Survey: http://www.surveygizmo.com/s3/25
 **Jenn** - writer for Doc's team (@jleaver)  
 **Stefan** - Services Engineer (@stoe)  
 **Jamie** - Services Engineer (@allthedoll)  
+
+[Git-based technical writing workflow – notes from a TC Camp session](https://ffeathers.wordpress.com/2016/01/24/git-based-technical-writing-workflow-notes-from-a-tc-camp-session/) - from Sarah Maddox, a TC Camp attendee.


### PR DESCRIPTION
I've added a link to my blog post about the walkthrough during which we created this GitHub repo. Let me know what you think about this change. :)
